### PR TITLE
ddw-0.13.01: Suites renamed/added.

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -14,6 +14,9 @@ platforms:
   - name: centos-7
 
 suites:
-  - name: default
+  - name: dev
     run_list:
     attributes:
+  # - name: test
+  # - name: stage
+  # - name: prod


### PR DESCRIPTION
Modified kitchen file to change default to dev and add test, stage, and prod, although the suites are commented out at present.