### PR TITLE
Return 404 for unknown hosts

### DIFF
--- a/templates/datagov.nginx.conf
+++ b/templates/datagov.nginx.conf
@@ -18,7 +18,7 @@ server {
     ssl_certificate {{ wordpress_tls_host_certificate_filepath }};
     ssl_certificate_key {{ wordpress_tls_host_key_filepath }};
     ssl_protocols {{ wordpress_tls_protocols }};
-    return 403;
+    return 404;
 }
 
 server {


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/pull/2636

404 is probably the best response for a host that is not supported.

403 implies that the [client may retry the URL with different credentials][1],
but that is not the case.

[1]: https://httpstatuses.com/403