### PR TITLE
add HSTS only for intenral traffic

### DIFF
--- a/templates/datagov.nginx.conf
+++ b/templates/datagov.nginx.conf
@@ -133,7 +133,16 @@ server {
 
         add_header "Referrer-Policy" "origin";
 
-        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; ";
+        # Avoid duplicate HSTS. Netscaler adds it for external traffic
+        if ( $host = $hostname ) {
+          set $internal_traffic 1;
+        }
+        if ( $host = {{ ansible_default_ipv4.address }} ) {
+          set $internal_traffic 1;
+        }
+        if ( $internal_traffic = 1 ) {
+          add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; ";
+        }
 
         # add_header "Content-Security-Policy" "default-src 'self' 'unsafe-inline' *.google-analytics.com *.googleapis.com cdn.datatables.net *.gov s.w.org; img-src *; font-src *";
 


### PR DESCRIPTION
For https://github.com/GSA/datagov-deploy/issues/2598.

Avoid duplicate HSTS. Netscaler adds it for external traffic.
This ensure Netsparker sees HSTS when it scan internal host, sees valid HSTS when it scans external URL.
This also means no HSTS for sandbox environment. 