### PR TITLE
add HSTS only for internal traffic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ default_email_from: datagov@localhost
 
 # wordpress app code
 wordpress_project_git_repo: https://github.com/GSA/datagov-wp-boilerplate.git
-wordpress_project_git_version: master
+wordpress_project_git_version: fcs
 
 # Project path
 project_source_rollback_path: /var/www/datagov/rollback

--- a/templates/datagov.nginx.conf
+++ b/templates/datagov.nginx.conf
@@ -133,7 +133,16 @@ server {
 
         add_header "Referrer-Policy" "origin";
 
-        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; ";
+        # Avoid duplicate HSTS. Netscaler adds it for external traffic
+        if ( $host = $hostname ) {
+          set $internal_traffic 1;
+        }
+        if ( $host = {{ ansible_default_ipv4.address }} ) {
+          set $internal_traffic 1;
+        }
+        if ( $internal_traffic = 1 ) {
+          add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; ";
+        }
 
         # add_header "Content-Security-Policy" "default-src 'self' 'unsafe-inline' *.google-analytics.com *.googleapis.com cdn.datatables.net *.gov s.w.org; img-src *; font-src *";
 


### PR DESCRIPTION
redo https://github.com/GSA/datagov-deploy-wordpress/pull/22 for master branch.
we are deleting freeze-fcs branch.