### PR TITLE
set internal_traffic variable

### DIFF
--- a/templates/datagov.nginx.conf
+++ b/templates/datagov.nginx.conf
@@ -134,6 +134,7 @@ server {
         add_header "Referrer-Policy" "origin";
 
         # Avoid duplicate HSTS. Netscaler adds it for external traffic
+        set $internal_traffic 0;
         if ( $host = $hostname ) {
           set $internal_traffic 1;
         }


### PR DESCRIPTION
get rid of repeated entry in nginx error log:
```
using uninitialized "Internal_traffic" variable ... 
```