### PR TITLE
add client_max_body_size to nginx

### DIFF
--- a/templates/datagov.nginx.conf
+++ b/templates/datagov.nginx.conf
@@ -29,6 +29,8 @@ server {
     ## This should be in your http block and if it is, it's not needed here.
     index index.php;
 
+    client_max_body_size: {{ client_max_body_size | default('1m') }}
+
     listen 443 ssl;
     ssl_certificate {{ wordpress_tls_host_certificate_filepath }};
     ssl_certificate_key {{ wordpress_tls_host_key_filepath }};


### PR DESCRIPTION
Did not see `client_max_body_size` support in `nginx_config_main_template` config, only in `nginx_config_http_template` config. Dashboard deploy is using a conf template file, therefore adding `client_max_body_size` here.